### PR TITLE
Exp bigint fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To use GuardianDb you'll need to add a migration
           add :aud, :string
           add :iss, :string
           add :sub, :string
-          add :exp, :integer
+          add :exp, :bigint
           add :jwt, :text
           add :claims, :text
           timestamps

--- a/test/guardian_db_test.exs
+++ b/test/guardian_db_test.exs
@@ -10,7 +10,7 @@ defmodule GuardianDbTest do
           "aud" => "token",
           "sub" => "the_subject",
           "iss" => "the_issuer",
-          "exp" => Guardian.Utils.timestamp + 5000,
+          "exp" => Guardian.Utils.timestamp + 1_000_000_000,
         }
       }
     }

--- a/test/support/migrations.exs
+++ b/test/support/migrations.exs
@@ -7,7 +7,7 @@ defmodule GuardianDb.Test.Repo.Migrations do
       add :aud, :string
       add :iss, :string
       add :sub, :string
-      add :exp, :integer
+      add :exp, :bigint
       add :jwt, :text
       add :claims, :text
 


### PR DESCRIPTION
The default TTL of 1_000_000_000 seconds was causing an ecto error when using integer. Fixed by changing to bigint
