### PR TITLE
claims field is used; stores the full claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use GuardianDb you'll need to add a migration
           add :sub, :string
           add :exp, :bigint
           add :jwt, :text
-          add :claims, :text
+          add :claims, :map
           timestamps
         end
       end

--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -29,7 +29,7 @@ defmodule GuardianDb do
       field :sub, :string
       field :exp, :integer
       field :jwt, :string
-      field :claims, :string
+      field :claims, :map
 
       timestamps
     end
@@ -38,8 +38,8 @@ defmodule GuardianDb do
     Create a new new token based on the JWT and decoded claims
     """
     def create!(claims, jwt) do
-      prepared_claims = claims |> Dict.put("jwt", jwt)
-      GuardianDb.repo.insert cast(%Token{}, prepared_claims, [], [:jti, :aud, :iss, :sub, :exp, :jwt])
+      prepared_claims = claims |> Dict.put("jwt", jwt) |> Dict.put("claims", claims)
+      GuardianDb.repo.insert cast(%Token{}, prepared_claims, [], [:jti, :aud, :iss, :sub, :exp, :jwt, :claims])
     end
 
     @doc """

--- a/test/guardian_db_test.exs
+++ b/test/guardian_db_test.exs
@@ -30,6 +30,7 @@ defmodule GuardianDbTest do
     assert token.sub == "the_subject"
     assert token.iss == "the_issuer"
     assert token.exp == context.claims["exp"]
+    assert token.claims == context.claims
   end
 
   test "on_verify with a record in the db", context do

--- a/test/support/migrations.exs
+++ b/test/support/migrations.exs
@@ -9,7 +9,7 @@ defmodule GuardianDb.Test.Repo.Migrations do
       add :sub, :string
       add :exp, :bigint
       add :jwt, :text
-      add :claims, :text
+      add :claims, :map
 
       timestamps
     end


### PR DESCRIPTION
see: https://github.com/hassox/guardian_db/issues/3

@hassox Is this what you had in mind? I had to change the schema, which I'm not a fan of, but it didn't serialize correctly with a string type. This gets me to the "pem" claims without decoding the JWT, which I do like :)
