### PR TITLE
Configurable schema name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Add this to your configuration:
 
     config :guardian_db, GuardianDb,
            repo: MyApp.Repo
+           schema_name: "tokens" # Optional, default is "guardian_tokens"
 ```
 
 It's a good idea to purge out any stale tokens that have already expired.

--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -22,8 +22,9 @@ defmodule GuardianDb do
 
     use Ecto.Model
     @primary_key {:jti, :string, autogenerate: false }
+    @schema_name Keyword.get(Application.get_env(:guardian_db, GuardianDb), :schema_name) || "guardian_tokens"
 
-    schema "guardian_tokens" do
+    schema @schema_name do
       field :typ, :string
       field :aud, :string
       field :iss, :string


### PR DESCRIPTION
The migration is largely in control of the user and so I thought it'd be nice to allow changing of the schema name.
