### PR TITLE
Scope jti with aud

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To use GuardianDb you'll need to add a migration
           add :claims, :map
           timestamps
         end
+        create unique_index(:guardian_tokens, [:jti, :aud])
       end
 
       def down do

--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -36,6 +36,15 @@ defmodule GuardianDb do
     end
 
     @doc """
+    Find one token by matching jti and aud
+    """
+    def find_by_claims(claims) do
+      jti = Dict.get(claims, "jti")
+      aud = Dict.get(claims, "aud")
+      GuardianDb.repo.get_by(Token, jti: jti, aud: aud)
+    end
+
+    @doc """
     Create a new new token based on the JWT and decoded claims
     """
     def create!(claims, jwt) do
@@ -69,9 +78,7 @@ defmodule GuardianDb do
   If the token is found, the verification continues, if not an error is returned.
   """
   def on_verify(claims, jwt) do
-    jti = Dict.get(claims, "jti")
-    aud = Dict.get(claims, "aud")
-    case repo.get_by(Token, jti: jti, aud: aud) do
+    case Token.find_by_claims(claims) do
       nil -> { :error, :token_not_found }
       _token -> { :ok, { claims, jwt } }
     end
@@ -81,8 +88,7 @@ defmodule GuardianDb do
   When logging out, or revoking a token, removes from the database so the token may no longer be used
   """
   def on_revoke(claims, jwt) do
-    jti = Dict.get(claims, "jti")
-    model = repo.get_by(Token, jti: jti)
+    model = Token.find_by_claims(claims)
     if model do
       case repo.delete(model) do
         { :error, _ } -> { :error, :could_not_revoke_token }

--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -69,7 +69,9 @@ defmodule GuardianDb do
   If the token is found, the verification continues, if not an error is returned.
   """
   def on_verify(claims, jwt) do
-    case repo.get_by(Token, jti: Dict.get(claims, "jti")) do
+    jti = Dict.get(claims, "jti")
+    aud = Dict.get(claims, "aud")
+    case repo.get_by(Token, jti: jti, aud: aud) do
       nil -> { :error, :token_not_found }
       _token -> { :ok, { claims, jwt } }
     end


### PR DESCRIPTION
### Problem

It's (remotely) possible that an issued `jti` is not globally unique.
### Solution

Get `guardian_tokens` by `jti` and `aud`.

Thoughts?

Also, on another note, I'm getting a dependency resolution conflict running `mix deps.get` on latest master here:

```
Running dependency resolution
Conflict on jose
  mix.lock: 1.4.2
  guardian 0.10.1: ~> 1.6

** (Mix) Hex dependency resolution failed, relax the version requirements or unlock dependencies
```
