### PR TITLE
Feature: Add configuration to only store one token type

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Add this to your configuration:
     config :guardian_db, GuardianDb,
            repo: MyApp.Repo
            schema_name: "tokens" # Optional, default is "guardian_tokens"
+           token_type: "refresh" # Optional, default is store all tokens
 ```
 
 It's a good idea to purge out any stale tokens that have already expired.

--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -65,23 +65,33 @@ defmodule GuardianDb do
   if !Keyword.get(Application.get_env(:guardian_db, GuardianDb), :repo), do: raise "GuardianDb requires a repo"
 
   @doc """
-  After the JWT is generated, stores the various fields of it in the DB for tracking
+  After the JWT is generated, stores the various fields of it in the DB for tracking,
+  assuming it matches the configured token type for storage
   """
+
   def after_encode_and_sign(resource, type, claims, jwt) do
-    case Token.create!(claims, jwt) do
-      { :error, _ } -> { :error, :token_storage_failure }
-      _ -> { :ok, { resource, type, claims, jwt } }
+    if configured_type_matches(type) do
+      case Token.create!(claims, jwt) do
+        { :error, _ } -> { :error, :token_storage_failure }
+        _ -> { :ok, { resource, type, claims, jwt } }
+      end
+    else
+      { :ok, { resource, type, claims, jwt } }
     end
   end
 
   @doc """
-  When a token is verified, check to make sure that it is present in the DB.
+  When a token is verified, check to make sure that it is present in the DB if it matches the configured token type
   If the token is found, the verification continues, if not an error is returned.
   """
   def on_verify(claims, jwt) do
-    case Token.find_by_claims(claims) do
-      nil -> { :error, :token_not_found }
-      _token -> { :ok, { claims, jwt } }
+    if configured_type_matches(claims["typ"]) do
+      case Token.find_by_claims(claims) do
+        nil -> { :error, :token_not_found }
+        _token -> { :ok, { claims, jwt } }
+      end
+    else
+      { :ok, {claims, jwt } }
     end
   end
 
@@ -99,6 +109,11 @@ defmodule GuardianDb do
     else
       { :ok, { claims, jwt } }
     end
+  end
+
+  def configured_type_matches(type) do
+    env_token_type = Keyword.get(Application.get_env(:guardian_db, GuardianDb), :token_type)
+    !(env_token_type && to_string(env_token_type) !== to_string(type))
   end
 
   def repo do

--- a/test/guardian_db_test.exs
+++ b/test/guardian_db_test.exs
@@ -3,11 +3,24 @@ defmodule GuardianDbTest do
   alias GuardianDb.Token
   alias GuardianDb.Test.Repo
 
+  def set_token_type(token) do
+    gd_env = Application.get_env(:guardian_db, GuardianDb)
+    gd_new_env = Keyword.put(gd_env, :token_type, token)
+    Application.put_env(:guardian_db, GuardianDb, gd_new_env)
+  end
+
+  def clear_token_type do
+    gd_env = Application.get_env(:guardian_db, GuardianDb)
+    gd_new_env = Keyword.delete(gd_env, :token_type)
+    Application.put_env(:guardian_db, GuardianDb, gd_new_env)
+  end
+
   setup do
     { :ok, %{
         claims: %{
           "jti" => "token-uuid",
           "aud" => "token",
+          "typ" => "token",
           "sub" => "the_subject",
           "iss" => "the_issuer",
           "exp" => Guardian.Utils.timestamp + 1_000_000_000,
@@ -16,7 +29,7 @@ defmodule GuardianDbTest do
     }
   end
 
-  test "after_encode_and_sign_in is successful", context do
+  test "after_encode_and_sign_in is successful, no token type set", context do
     token = Repo.get(Token, "token-uuid")
     assert token == nil
 
@@ -27,10 +40,45 @@ defmodule GuardianDbTest do
     assert token != nil
     assert token.jti == "token-uuid"
     assert token.aud == "token"
+    assert token.typ == "token"
     assert token.sub == "the_subject"
     assert token.iss == "the_issuer"
     assert token.exp == context.claims["exp"]
     assert token.claims == context.claims
+  end
+
+  test "after_encode_and_sign_in is successful, token type matches", context do
+    token = Repo.get(Token, "token-uuid")
+    assert token == nil
+
+    set_token_type(:token)
+    GuardianDb.after_encode_and_sign(%{}, :token, context.claims, "The JWT")
+    clear_token_type
+
+    token = Repo.get(Token, "token-uuid")
+
+    assert token != nil
+    assert token.jti == "token-uuid"
+    assert token.aud == "token"
+    assert token.typ == "token"
+    assert token.sub == "the_subject"
+    assert token.iss == "the_issuer"
+    assert token.exp == context.claims["exp"]
+    assert token.claims == context.claims
+
+
+  end
+
+  test "after_encode_and_sign_in is successful, token type mismatch", context do
+    token = Repo.get(Token, "token-uuid")
+    assert token == nil
+
+    set_token_type(:refresh)
+    GuardianDb.after_encode_and_sign(%{}, :token, context.claims, "The JWT")
+    clear_token_type
+
+    token = Repo.get(Token, "token-uuid")
+    assert token == nil
   end
 
   test "on_verify with a record in the db", context do
@@ -41,10 +89,26 @@ defmodule GuardianDbTest do
     assert { :ok, { context.claims, "The JWT" } } == GuardianDb.on_verify(context.claims, "The JWT")
   end
 
-  test "on_verify without a record in the db", context do
+  test "on_verify without a record in the db, no token type", context do
     token = Repo.get(Token, "token-uuid")
     assert token == nil
     assert { :error, :token_not_found } == GuardianDb.on_verify(context.claims, "The JWT")
+  end
+
+  test "on_verify without a record in the db, token type matches", context do
+    token = Repo.get(Token, "token-uuid")
+    assert token == nil
+    set_token_type(:token)
+    assert { :error, :token_not_found } == GuardianDb.on_verify(context.claims, "The JWT")
+    clear_token_type
+  end
+
+  test "on_verify without a record in the db, token type mismatch", context do
+    token = Repo.get(Token, "token-uuid")
+    assert token == nil
+    set_token_type(:refresh)
+    assert { :ok, { context.claims, "The JWT" } } == GuardianDb.on_verify(context.claims, "The JWT")
+    clear_token_type
   end
 
   test "on_revoke without a record in the db", context do


### PR DESCRIPTION
Hey! This is an additional feature that would allow you to only store tokens that match a certain type. My thinking is if you want to add refresh tokens to Guardian, then the ideal scenario is to set short expirations on the access tokens and not worry about storing then (therefore avoiding a DB check) but to store refresh tokens in a DB so you can revoke them if they are compromised (or a user logs out).

So you'd use GuardianDB only for tokens of type "refresh" for example.
