### PR TITLE
Include missing comma in example configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Add this to your configuration:
            #…
 
     config :guardian_db, GuardianDb,
-           repo: MyApp.Repo
+           repo: MyApp.Repo,
            schema_name: "tokens" # Optional, default is "guardian_tokens"
 ```
 


### PR DESCRIPTION
The example configuration of `:guardian_db` is missing a comma between arguments and doesn't compile if copied/pasted.
