### PR TITLE
Add ability to set @schema_prefix for table.

### DIFF
--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -23,6 +23,7 @@ defmodule GuardianDb do
     use Ecto.Schema
     @primary_key {:jti, :string, autogenerate: false }
     @schema_name Keyword.get(Application.get_env(:guardian_db, GuardianDb), :schema_name) || "guardian_tokens"
+    @schema_prefix Keyword.get(Application.get_env(:guardian_db, GuardianDb), :prefix) || nil
 
     import Ecto.Changeset
     import Ecto.Query


### PR DESCRIPTION
This option is necessary in case a user is not placing the tokens table
in the 'public' schema (Postgres) or is using the prefix option for
other tables in their app (MySQL).

If not set in the config, will default to nil, meaning no prefix.
