### PR TITLE
Use composite primary key to enable #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ To use GuardianDb you'll need to add a migration
     defmodule MyApp.Repo.Migrations.GuardianDb do
       use Ecto.Migration
 
-      def up do
+      def change do
+
         create table(:guardian_tokens, primary_key: false) do
           add :jti, :string, primary_key: true
-          add :typ, :string
-          add :aud, :string
+          add :aud, :string, primary_key: true
           add :iss, :string
           add :sub, :string
           add :exp, :bigint
@@ -53,12 +53,9 @@ To use GuardianDb you'll need to add a migration
           add :claims, :map
           timestamps
         end
-        create unique_index(:guardian_tokens, [:jti, :aud])
-      end
 
-      def down do
-        drop table(:guardian_tokens)
       end
+      
     end
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To use GuardianDb you'll need to add a migration
         create table(:guardian_tokens, primary_key: false) do
           add :jti, :string, primary_key: true
           add :aud, :string, primary_key: true
+          add :typ, :string
           add :iss, :string
           add :sub, :string
           add :exp, :bigint


### PR DESCRIPTION
Following https://github.com/hassox/guardian_db/pull/14 for this to work you'd need a composite primary key and not just an extra unique index.

Currently `jti` is already set as primary key and (at least in PostgreSQL) that means it will be unique. Inserting an entry with a non unique `jti` to the table will just cause error so another unique index doesn't do anything and the whole lookup by extra field change seem to be superfluous, it should work as intended with the composite key. 
