### PR TITLE
fix(warn): change from cast/4 to cast/3

### DIFF
--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -54,7 +54,7 @@ defmodule GuardianDb do
     """
     def create!(claims, jwt) do
       prepared_claims = claims |> Dict.put("jwt", jwt) |> Dict.put("claims", claims)
-      GuardianDb.repo.insert cast(%Token{}, prepared_claims, [], [:jti, :typ, :aud, :iss, :sub, :exp, :jwt, :claims])
+      GuardianDb.repo.insert cast(%Token{}, prepared_claims, [:jti, :typ, :aud, :iss, :sub, :exp, :jwt, :claims])
     end
 
     @doc """


### PR DESCRIPTION
Also, should `validate_required/3` be used for `jti` and `aud` as these are used in the composite pk?