### PR TITLE
changes for guardian 1.0

### DIFF
--- a/lib/guardian_db.ex
+++ b/lib/guardian_db.ex
@@ -106,7 +106,6 @@ defmodule GuardianDb do
          hooks: GuardianDb
   ```
   """
-  use Guardian.Hooks
 
   config = Application.get_env(:guardian_db, GuardianDb, [])
   @repo Keyword.get(config, :repo)
@@ -168,7 +167,7 @@ defmodule GuardianDb do
     Purge any tokens that are expired. This should be done periodically to keep your DB table clean of clutter
     """
     def purge_expired_tokens! do
-      timestamp = Guardian.Utils.timestamp()
+      timestamp = Guardian.timestamp()
       from(t in Token, where: t.exp < ^timestamp) |> GuardianDb.repo.delete_all()
     end
   end

--- a/test/guardian_db_test.exs
+++ b/test/guardian_db_test.exs
@@ -11,7 +11,7 @@ defmodule GuardianDbTest do
           "aud" => "token",
           "sub" => "the_subject",
           "iss" => "the_issuer",
-          "exp" => Guardian.Utils.timestamp() + 1_000_000_000,
+          "exp" => Guardian.timestamp() + 1_000_000_000,
         }
       }
     }
@@ -67,8 +67,8 @@ defmodule GuardianDbTest do
   end
 
   test "purge stale tokens" do
-    Token.create! %{"jti" => "token1", "exp" => Guardian.Utils.timestamp + 5000}, "Token 1"
-    Token.create! %{"jti" => "token2", "exp" => Guardian.Utils.timestamp - 5000}, "Token 2"
+    Token.create! %{"jti" => "token1", "exp" => Guardian.timestamp + 5000}, "Token 1"
+    Token.create! %{"jti" => "token2", "exp" => Guardian.timestamp - 5000}, "Token 2"
 
     Token.purge_expired_tokens!
 


### PR DESCRIPTION
Made changes to make GuardianDB compatible with Guardian 1.0.
 * Removed `using Guardian.Hooks`
 * Changed `Guardian.Utils.timestamp()` to `Guardian.timestamp()`