### PR TITLE
change guardian 1.0  to 1.0.0-beta.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule GuardianDb.Mixfile do
   defp _elixirc_paths(_), do: ["lib"]
 
   defp deps do
-    [{:guardian, ">= 1.0"},
+    [{:guardian, ">= 1.0.0-beta.0"},
      {:ecto, "~> 2.1 or ~> 2.2"},
      {:postgrex, ">= 0.11.1 or >= 0.13", optional: true},
      {:ex_doc, ">= 0.16", only: :dev},


### PR DESCRIPTION
change guardian version reference from 1.0  to 1.0.0-beta.0


Mentioned in issue #57 