### PR TITLE
updated postgrex to only >= 0.13

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule GuardianDb.Mixfile do
   defp deps do
     [{:guardian, ">= 1.0"},
      {:ecto, "~> 2.1 or ~> 2.2"},
-     {:postgrex, ">= 0.11.1 or >= 0.13", optional: true},
+     {:postgrex, ">= 0.13", optional: true},
      {:ex_doc, ">= 0.16", only: :dev},
      {:earmark, ">= 0.0.0", only: :dev}]
   end


### PR DESCRIPTION
Hello,
I am getting below error when doing mix compile
** (Mix) Invalid requirement >= 0.11.1 or >= 0.13 for app postgrex
I think we either want one of >= 0.11.1 or >= 0.13 to fix this one.