### PR TITLE
Update README.md to use the appropriate migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then run `mix deps.get` on your terminal.
 
 You will then need to add a migration:
 
-run `mix guardian_db.gen.migration` to generate a migration.
+run `mix guardian.DB.gen.migration` to generate a migration.
 
 **Do not run the migration yet,** we need to complete our setup first.
 


### PR DESCRIPTION
## Overview
This is two problems:
1. The readme gives the wrong command to be run for migrations
1. The error gives the wrong command to be run also due to being case sensitive

### Errors
![image](https://user-images.githubusercontent.com/1325608/33451283-68c0bfbc-d5c3-11e7-8556-0286bea460d4.png)
![image](https://user-images.githubusercontent.com/1325608/33451388-c327556a-d5c3-11e7-8c77-80f50cee6729.png)

### Success
```bash
mix guardian.DB.gen.migration
* creating priv/repo/migrations
* creating priv/repo/migrations/20171130193417_guardiandb.exs
```