### PR TITLE
Add back support for configuring DB prefix:

### DIFF
--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -78,7 +78,8 @@ defmodule Guardian.DB.Token do
     |> Keyword.get(:schema_name, "guardian_tokens")
   end
 
-  defp prefix do
+  @doc false
+  def prefix do
     :guardian
     |> Application.fetch_env!(Guardian.DB)
     |> Keyword.get(:prefix, nil)

--- a/lib/mix/tasks/guardian_db.gen.migration.ex
+++ b/lib/mix/tasks/guardian_db.gen.migration.ex
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.Guardian.Db.Gen.Migration do
 
   import Mix.Ecto
   import Mix.Generator
+  alias Guardian.DB.Token
 
   @doc false
   def run(args) do
@@ -24,7 +25,9 @@ defmodule Mix.Tasks.Guardian.Db.Gen.Migration do
         |> Application.app_dir()
         |> Path.join("priv/templates/migration.exs.eex")
 
-      generated_file = EEx.eval_file(source_path, module_prefix: app_module())
+      generated_file = EEx.eval_file(source_path,
+                                     module_prefix: app_module(),
+                                     db_prefix: Token.prefix())
       target_file = Path.join(path, "#{timestamp()}_guardiandb.exs")
       create_directory(path)
       create_file(target_file, generated_file)

--- a/priv/templates/migration.exs.eex
+++ b/priv/templates/migration.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.Guardian.DB do
   use Ecto.Migration
 
   def change do
-    create table(:guardian_tokens, primary_key: false) do
+    create table(:guardian_tokens, primary_key: false<%= if not is_nil(db_prefix), do: ", prefix: \"#{db_prefix}\"" %>) do
       add(:jti, :string, primary_key: true)
       add(:aud, :string, primary_key: true)
       add(:typ, :string)


### PR DESCRIPTION
## Description

I noticed the "prefix" setting described in the [config section of the docs](https://hexdocs.pm/guardian_db/1.1.0/Guardian.DB.html#module-config) does not actually change anything.

This prevents me from upgrading to guardian_db 1.x from the < 1.0 version, which did support it.

## Proposed Solution

The code modifies the Token module to look up and use the configuration for the prefix. It defaults to `nil`, so all existing configurations should continue to work.

It also adds a bit of logic to the migration generator so that the prefix is included there as well.

### Contributing

I'm not sure if you'd prefer this PR from a branch off of master or some other format - let me know and I'll adjust accordingly.