### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ defmodule MyApp.AuthTokens do
   end
 
   def on_refresh({old_token, old_claims}, {new_token, new_claims}, _options) do
-    with {:ok, _} <- Guardian.DB.on_refresh({old_token, old_claims}, {new_token, new_claims}) do
+    with {:ok, _, _} <- Guardian.DB.on_refresh({old_token, old_claims}, {new_token, new_claims}) do
       {:ok, {old_token, old_claims}, {new_token, new_claims}}
     end
   end


### PR DESCRIPTION
The success typing for `on_refresh` is `{'ok',{_,map()},{_,'nil' | [{_,_}] | map()}}` according to both Dialyzer and the source at https://github.com/ueberauth/guardian_db/blob/ef024b6d4d84cf06573bc9d8c44dcb9a99a67ca7/lib/guardian/db.ex#L166. Therefore, the example in the documentation can never match unless you match against three elements in the tuple.