### PR TITLE
handle stale ecto errors on delete

### DIFF
--- a/lib/guardian/db.ex
+++ b/lib/guardian/db.ex
@@ -172,7 +172,7 @@ defmodule Guardian.DB do
   defp destroy_token(nil, claims, jwt), do: {:ok, {claims, jwt}}
 
   defp destroy_token(model, claims, jwt) do
-    case repo().delete(model) do
+    case repo().delete(model, stale_error_field: :stale_token) do
       {:error, _} -> {:error, :could_not_revoke_token}
       nil -> {:error, :could_not_revoke_token}
       _ -> {:ok, {claims, jwt}}

--- a/test/guardian/db_test.exs
+++ b/test/guardian/db_test.exs
@@ -87,6 +87,13 @@ defmodule Guardian.DB.Test do
     assert token == nil
   end
 
+  test "on_revoke with a stale token", context do
+    Token.create(context.claims, "The JWT")
+
+    assert Guardian.DB.on_revoke(context.claims, "The JWT") == {:ok, {context.claims, "The JWT"}}
+    assert Guardian.DB.on_revoke(context.claims, "The JWT") == {:error, _changeset}
+  end
+
   test "purge stale tokens" do
     Token.create(
       %{"jti" => "token1", "aud" => "token", "exp" => Guardian.timestamp() + 5000},

--- a/test/guardian/db_test.exs
+++ b/test/guardian/db_test.exs
@@ -87,17 +87,6 @@ defmodule Guardian.DB.Test do
     assert token == nil
   end
 
-  test "on_revoke with a stale token", context do
-    Token.create(context.claims, "The JWT")
-
-    assert Guardian.DB.on_revoke(context.claims, "The JWT") == {:ok, {context.claims, "The JWT"}}
-
-    token = get_token()
-    assert token == nil
-
-    {:error, :could_not_revoke_token} = Guardian.DB.on_revoke(context.claims, "The JWT")
-  end
-
   test "purge stale tokens" do
     Token.create(
       %{"jti" => "token1", "aud" => "token", "exp" => Guardian.timestamp() + 5000},

--- a/test/guardian/db_test.exs
+++ b/test/guardian/db_test.exs
@@ -91,7 +91,11 @@ defmodule Guardian.DB.Test do
     Token.create(context.claims, "The JWT")
 
     assert Guardian.DB.on_revoke(context.claims, "The JWT") == {:ok, {context.claims, "The JWT"}}
-    assert Guardian.DB.on_revoke(context.claims, "The JWT") == {:error, _changeset}
+
+    token = get_token()
+    assert token == nil
+
+    {:error, :could_not_revoke_token} = Guardian.DB.on_revoke(context.claims, "The JWT")
   end
 
   test "purge stale tokens" do


### PR DESCRIPTION
Addresses #102 

Looks like we can pass an option to [Ecto.Repo.delete/2](https://hexdocs.pm/ecto/Ecto.Repo.html#c:delete/2) that will map a stale error into a field in the change set. 