### PR TITLE
Add revoke_all/2

### DIFF
--- a/lib/guardian/db.ex
+++ b/lib/guardian/db.ex
@@ -166,6 +166,40 @@ defmodule Guardian.DB do
     |> Token.destroy_token(claims, jwt)
   end
 
+  @doc """
+  Revoke all tokens of a given subject. Returns the amount of tokens revoked.
+
+  ## Usage
+
+  Add to your `Guardian` module.
+
+  ```elixir
+  defmodule MyApp.AuthTokens do
+    use Guardian, otp_app: :my_app
+
+    # snip...
+
+    def revoke_all(resource, claims) do
+      with {:ok, sub} <- subject_for_token(resource, claims) do
+        Guardian.DB.revoke_all(resource)
+      end
+    end
+  end
+  ```
+
+  Then you revoke all tokens of a resource.
+
+  ```elixir
+  MyApp.AuthTokens.revoke_all(resource, %{})
+  ```
+
+  """
+  def revoke_all(sub) do
+    {amount_deleted, _} = Token.destroy_by_sub(sub)
+
+    {:ok, amount_deleted}
+  end
+
   @doc false
   def repo do
     :guardian

--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -69,9 +69,10 @@ defmodule Guardian.DB.Token do
 
   @doc false
   def destroy_by_sub(sub) do
-    query = query_schema()
-    |> where([token], token.sub == ^sub)
-    |> Map.put(:prefix, prefix())
+    query =
+      query_schema()
+      |> where([token], token.sub == ^sub)
+      |> Map.put(:prefix, prefix())
 
     Guardian.DB.repo().delete_all(query)
   end

--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -68,6 +68,15 @@ defmodule Guardian.DB.Token do
   end
 
   @doc false
+  def destroy_by_sub(sub) do
+    query = query_schema()
+    |> where([token], token.sub == ^sub)
+    |> Map.put(:prefix, prefix())
+
+    Guardian.DB.repo().delete_all(query)
+  end
+
+  @doc false
   def query_schema do
     {schema_name(), Token}
   end

--- a/test/guardian/db_test.exs
+++ b/test/guardian/db_test.exs
@@ -105,4 +105,26 @@ defmodule Guardian.DBTest do
     assert token1 != nil
     assert token2 == nil
   end
+
+  test "revoke_all deletes all tokens of a sub" do
+    sub = "the_subject"
+
+    Token.create(
+      %{"jti" => "token1", "aud" => "token", "exp" => Guardian.timestamp(), "sub" => sub},
+      "Token 1"
+    )
+
+    Token.create(
+      %{"jti" => "token2", "aud" => "token", "exp" => Guardian.timestamp(), "sub" => sub},
+      "Token 2"
+    )
+
+    Token.create(
+      %{"jti" => "token3", "aud" => "token", "exp" => Guardian.timestamp(), "sub" => sub},
+      "Token 3"
+    )
+
+    assert Guardian.DB.revoke_all(sub) == {:ok, 3}
+    assert Repo.all(Token.query_schema()) == []
+  end
 end


### PR DESCRIPTION
## Motivation

In some authentication flows, we want to revoke all tokens of a user/resource after a password update. Closes ueberauth/guardian#651.

## Proposed solution

Introduce `revoke_all/2` in the `Guardian.DB` API