### PR TITLE
configure app prior to migration generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ end
 
 Then run `mix deps.get` on your terminal.
 
-You will then need to add a migration:
+Configure your application as seen in the *Configuration* section below prior to attempting to generate the migration or you will get an `application was not loaded/started` error.
+
+Following configuration add the Guardian migration:
 
 run `mix guardian.db.gen.migration` to generate a migration.
 


### PR DESCRIPTION
An ArgumentError occurs when trying to run `mix guardian.db.gen.migration` prior to configuring the app. Since I followed the *README* from top to bottom I attempted to generate the migration and ended up with a `application was not loaded/started` error:
````
** (ArgumentError) could not fetch application environment Guardian.DB for application :guardian because the application was not loaded/started. If your application depends on :guardian at runtime, make sure to load/start it or list it under :extra_applications in your mix.exs file
````

This PR clarifies the instructions.