### PR TITLE
feat(token_storage): return error reason

### DIFF
--- a/lib/guardian/db.ex
+++ b/lib/guardian/db.ex
@@ -110,7 +110,7 @@ defmodule Guardian.DB do
   """
   def after_encode_and_sign(resource, type, claims, jwt) do
     case store_token(type, claims, jwt) do
-      {:error, _} -> {:error, :token_storage_failure}
+      {:error, reason} -> {:error, :token_storage_failure, reason}
       _ -> {:ok, {resource, type, claims, jwt}}
     end
   end


### PR DESCRIPTION
Hello there,
This is my first PR in elixir ecosystem so if I'm missing something, please let me know.

So I got stuck for almost a day because of `:token_storage_failure` and no clue how to proceed, what helped is when I modified guardian_db to log the reason out.

Currently it's eating the error reason and not telling user why.

Normally I'd be like:
![image](https://user-images.githubusercontent.com/3640284/106434864-ae807380-64a4-11eb-8712-db2085127b4c.png)

But because it's very important to not have this kind of error eating stuff, I want to return the reason instead.

Please have a look :slightly_smiling_face: 