### PR TITLE
make jti and aud required fields, since they are primary keys

### DIFF
--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -10,6 +10,7 @@ defmodule Guardian.DB.Token do
   alias Guardian.DB.Token
 
   @primary_key {:jti, :string, autogenerate: false}
+  @required_fields ~w(jti aud)a
   @allowed_fields ~w(jti typ aud iss sub exp jwt claims)a
 
   schema "virtual: token" do
@@ -52,6 +53,7 @@ defmodule Guardian.DB.Token do
     |> Ecto.put_meta(source: schema_name())
     |> Ecto.put_meta(prefix: prefix())
     |> cast(prepared_claims, @allowed_fields)
+    |> validate_required(@required_fields)
     |> Guardian.DB.repo().insert()
   end
 

--- a/test/guardian/db_fail_test.exs
+++ b/test/guardian/db_fail_test.exs
@@ -1,0 +1,15 @@
+defmodule Guardian.DBFailTest do
+  alias Guardian.DB.Token
+  use Guardian.DB.TestSupport.CaseTemplate
+
+  test "after_encode_and_sign_in is fails", context do
+    token = get_token()
+    assert token == nil
+
+    {:error, :token_storage_failure} =
+      Guardian.DB.after_encode_and_sign(%{}, "token", %{}, "The JWT")
+
+    token = get_token()
+    assert token == nil
+  end
+end


### PR DESCRIPTION
After seeing #120 I released we have to test that actually hit this case. So I decided to clean up the token module a bit up. I have changed `jti` and `aud` to be required fields since they are already primary keys and the insert actually hard fails if they are missing. Now we til hit our `token_storage_failure`. Let me know what you think 