### PR TITLE
feat(migration_name): allow migrations with custom table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ end
 
 Now run the migration and you'll be good to go.
 
+### Custom schema name
+
+`Guardian.DB` allows custom schema name in migrations, based on following
+configuration:
+
+```elixir
+config :guardian, Guardian.DB,
+  schema_name: "my_custom_schema"
+```
+
+And when you run the migration, it'll generate the following migration:
+
+```elixir
+  create table(:my_custom_schema, primary_key: false) do
+    add(:jti, :string, primary_key: true)
+    add(:typ, :string)
+    add(:aud, :string)
+    add(:iss, :string)
+    add(:sub, :string)
+    add(:exp, :bigint)
+    add(:jwt, :text)
+    add(:claims, :map)
+    timestamps()
+  end
+```
+
+Then, run the migration and you'll be good to go.
+
 ### Considerations
 
 `Guardian` is already a very robust JWT solution. However, if your

--- a/lib/guardian/db.ex
+++ b/lib/guardian/db.ex
@@ -64,6 +64,31 @@ defmodule Guardian.DB do
     end
   ```
 
+  `Guardian.DB` allow to use a custom schema name when creating the migration.
+  You can configure the schema name from config like the following:
+
+  ```elixir
+  config :guardian, Guardian.DB,
+    schema_name: "my_customy_custom_schema
+  ```
+
+  And when you run `mix guardian.db.gen.migration` it'll generate the following
+  migration:
+
+  ```elixir
+    create table(:my_custom_schema, primary_key: false) do
+      add(:jti, :string, primary_key: true)
+      add(:typ, :string)
+      add(:aud, :string)
+      add(:iss, :string)
+      add(:sub, :string)
+      add(:exp, :bigint)
+      add(:jwt, :text)
+      add(:claims, :map)
+      timestamps()
+    end
+  ```
+
   `Guardian.DB` works by hooking into the lifecycle of your token module.
 
   You'll need to add it to

--- a/lib/mix/tasks/guardian_db.gen.migration.ex
+++ b/lib/mix/tasks/guardian_db.gen.migration.ex
@@ -3,6 +3,9 @@ defmodule Mix.Tasks.Guardian.Db.Gen.Migration do
 
   @moduledoc """
   Generates the required GuardianDb's database migration.
+
+  It allows custom schema name, using the config
+  entry `schema_name`.
   """
   use Mix.Task
 

--- a/lib/mix/tasks/guardian_db.gen.migration.ex
+++ b/lib/mix/tasks/guardian_db.gen.migration.ex
@@ -25,9 +25,16 @@ defmodule Mix.Tasks.Guardian.Db.Gen.Migration do
         |> Application.app_dir()
         |> Path.join("priv/templates/migration.exs.eex")
 
+      schema_name =
+        :guardian
+        |> Application.fetch_env!(Guardian.DB)
+        |> Keyword.get(:schema_name, "guardian_tokens")
+        |> String.to_atom()
+
       generated_file =
         EEx.eval_file(source_path,
           module_prefix: app_module(),
+          schema_name: schema_name,
           db_prefix: Token.prefix()
         )
 

--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule Guardian.DB.Mixfile do
       {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:excoveralls, ">= 0.0.0", only: [:test], runtime: false},
+      {:temporary_env, ">= 0.0.0", only: [:test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:inch_ex, ">= 0.0.0", only: [:dev], runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -29,4 +29,5 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+  "temporary_env": {:hex, :temporary_env, "2.0.1", "d4b5e031837e5619485e1f23af7cba7e897b8fd546eaaa8b10c812d642ec4546", [:mix], [], "hexpm", "f9420044742b5f0479a7f8243e86b048b6a2d4878bce026a3615065b11199c27"},
 }

--- a/priv/templates/migration.exs.eex
+++ b/priv/templates/migration.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateGuardianDBTokensTable do
   use Ecto.Migration
 
   def change do
-    create table(:guardian_tokens, primary_key: false<%= if not is_nil(db_prefix), do: ", prefix: \"#{db_prefix}\"" %>) do
+    create table(<%= inspect(schema_name) %>, primary_key: false<%= if not is_nil(db_prefix), do: ", prefix: \"#{db_prefix}\"" %>) do
       add(:jti, :string, primary_key: true)
       add(:aud, :string, primary_key: true)
       add(:typ, :string)

--- a/test/mix/tasks/guardian.db.gen.migration_test.exs
+++ b/test/mix/tasks/guardian.db.gen.migration_test.exs
@@ -3,6 +3,8 @@ defmodule Mix.Tasks.Guardian.Db.Gen.MigrationTest do
   import Mix.Tasks.Guardian.Db.Gen.Migration, only: [run: 1]
   import Guardian.DB.TestSupport.FileHelpers
 
+  require TemporaryEnv
+
   @tmp_path Path.join(tmp_path(), inspect(Guardian.Db.Gen.Migration))
   @migrations_path Path.join(@tmp_path, "migrations")
 
@@ -26,5 +28,20 @@ defmodule Mix.Tasks.Guardian.Db.Gen.MigrationTest do
     run(["-r", to_string(My.Repo)])
     assert [name] = File.ls!(@migrations_path)
     assert String.match?(name, ~r/^\d{14}_guardiandb\.exs$/)
+  end
+
+  test "generates a new migration with custom name" do
+    custom_schema_name = "my_custom_guardian_tokens"
+    value = [schema_name: custom_schema_name]
+
+    TemporaryEnv.put :guardian, Guardian.DB, value do
+      run(["-r", to_string(My.Repo)])
+      assert [name] = File.ls!(@migrations_path)
+
+      path = Path.join(@migrations_path, name)
+
+      assert String.match?(name, ~r/^\d{14}_guardiandb\.exs$/)
+      assert File.read!(path) =~ ":#{custom_schema_name}"
+    end
   end
 end


### PR DESCRIPTION
As requested from issue, this PR allows to use migration with custom schema names from the config. I also added the `temporary_env` dependency that allows to test temporary configs from the application.

Feel free to make changes :) 

Closes #118.