### PR TITLE
Pass prefix in the options for Repo functions

### DIFF
--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -51,7 +51,7 @@ defmodule Guardian.DB.Token do
     |> Ecto.put_meta(prefix: prefix())
     |> cast(prepared_claims, @allowed_fields)
     |> validate_required(@required_fields)
-    |> Guardian.DB.repo().insert()
+    |> Guardian.DB.repo().insert(prefix: prefix())
   end
 
   @doc """
@@ -96,7 +96,7 @@ defmodule Guardian.DB.Token do
   def destroy_token(nil, claims, jwt), do: {:ok, {claims, jwt}}
 
   def destroy_token(model, claims, jwt) do
-    case Guardian.DB.repo().delete(model) do
+    case Guardian.DB.repo().delete(model, prefix: prefix()) do
       {:error, _} -> {:error, :could_not_revoke_token}
       nil -> {:error, :could_not_revoke_token}
       _ -> {:ok, {claims, jwt}}

--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -32,12 +32,9 @@ defmodule Guardian.DB.Token do
     jti = Map.get(claims, "jti")
     aud = Map.get(claims, "aud")
 
-    query =
-      query_schema()
-      |> where([token], token.jti == ^jti and token.aud == ^aud)
-      |> Map.put(:prefix, prefix())
-
-    Guardian.DB.repo().one(query)
+    query_schema()
+    |> where([token], token.jti == ^jti and token.aud == ^aud)
+    |> Guardian.DB.repo().one(prefix: prefix())
   end
 
   @doc """
@@ -71,12 +68,9 @@ defmodule Guardian.DB.Token do
 
   @doc false
   def destroy_by_sub(sub) do
-    query =
-      query_schema()
-      |> where([token], token.sub == ^sub)
-      |> Map.put(:prefix, prefix())
-
-    Guardian.DB.repo().delete_all(query)
+    query_schema()
+    |> where([token], token.sub == ^sub)
+    |> Guardian.DB.repo().delete_all(prefix: prefix())
   end
 
   @doc false


### PR DESCRIPTION
`Repo.one` expects the prefix to be passed as an options.

See: https://hexdocs.pm/ecto/Ecto.Repo.html#c:one/2-options