### PR TITLE
Storage adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,32 @@ there isn't a good enough reason to reinvent that wheel using JWTs.
 In other words, once you have reached a point where you think you need
 `Guardian.DB`, it may be time to take a step back and reconsider your whole
 approach to authentication!
+
+### Guardian.DB Redis repo
+
+To improve situation described in "Disadvantages" section you can use Redis repo instead of Postgres repo.
+In order to do it you need add following configuration:
+
+Add to your mix.exs file new [`guardian_redis`](https://github.com/alexfilatov/guardian_redis) dependency:
+
+```elixir
+defp deps do
+  [
+    {:guardian_redis, "~> 0.1"}
+  ]
+end
+```
+
+Configure Redis repo in Guardian.DB configuration:
+
+```elixir
+config :guardian, Guardian.DB,
+  repo: GuardianRedis.Repo
+```
+
+Apart from this you will need to configure [Redis connection for `guardian_redis`](https://github.com/alexfilatov/guardian_redis#configuration) 
+
+### Create your own Repo
+
+We created `Guardian.DB.Adapter` behaviour to allow creating other repositories for persisting JWT tokens. 
+You need to implement only 5 methods to make Guardian.DB working with your preferred storage.     

--- a/README.md
+++ b/README.md
@@ -198,4 +198,4 @@ Apart from this you will need to configure [Redis connection for `guardian_redis
 ### Create your own Repo
 
 We created `Guardian.DB.Adapter` behaviour to allow creating other repositories for persisting JWT tokens. 
-You need to implement only 5 methods to make Guardian.DB working with your preferred storage.     
+You need to implement the `Guardian.DB.Adapter` behavior working with your preferred storage.     

--- a/README.md
+++ b/README.md
@@ -171,31 +171,13 @@ In other words, once you have reached a point where you think you need
 `Guardian.DB`, it may be time to take a step back and reconsider your whole
 approach to authentication!
 
-### Guardian.DB Redis repo
-
-To improve situation described in "Disadvantages" section you can use Redis repo instead of Postgres repo.
-In order to do it you need add following configuration:
-
-Add to your mix.exs file new [`guardian_redis`](https://github.com/alexfilatov/guardian_redis) dependency:
-
-```elixir
-defp deps do
-  [
-    {:guardian_redis, "~> 0.1"}
-  ]
-end
-```
-
-Configure Redis repo in Guardian.DB configuration:
-
-```elixir
-config :guardian, Guardian.DB,
-  repo: GuardianRedis.Repo
-```
-
-Apart from this you will need to configure [Redis connection for `guardian_redis`](https://github.com/alexfilatov/guardian_redis#configuration) 
-
 ### Create your own Repo
 
 We created `Guardian.DB.Adapter` behaviour to allow creating other repositories for persisting JWT tokens. 
 You need to implement the `Guardian.DB.Adapter` behavior working with your preferred storage.     
+
+### Adapters
+
+1. Redis adapter - [`guardian_redis`](https://github.com/alexfilatov/guardian_redis)
+
+Feel free to create your adapters using `Guardian.DB.Adapter` behavior and you are welcome to add them here.

--- a/lib/guardian/db/adapter.ex
+++ b/lib/guardian/db/adapter.ex
@@ -14,7 +14,6 @@ defmodule Guardian.DB.Adapter do
   @typep id :: pos_integer() | binary() | Ecto.UUID.t()
 
   @callback one(queryable()) :: nil | schema()
-  @callback get(queryable(), id()) :: nil | schema()
   @callback insert(schema_or_changeset()) :: {:ok, schema()}
   @callback delete(schema_or_changeset()) :: {:ok, schema()}
   @callback delete_all(queryable()) :: {:ok, pos_integer()}

--- a/lib/guardian/db/adapter.ex
+++ b/lib/guardian/db/adapter.ex
@@ -1,0 +1,22 @@
+defmodule Guardian.DB.Adapter do
+  @moduledoc """
+  The Guardian DB Adapter.
+
+  This behaviour allows to use any storage system
+  for Guardian Tokens.
+  """
+
+  @typep query :: Ecto.Query.t()
+  @typep schema :: Ecto.Schema.t()
+  @typep schema_or_changeset :: schema() | Ecto.Changeset.t()
+  @typep queryable :: query() | schema()
+  @typep opts :: keyword()
+  @typep id :: pos_integer() | binary() | Ecto.UUID.t()
+
+  @callback one(queryable()) :: nil | schema()
+  @callback get(queryable(), id()) :: nil | schema()
+  @callback insert(schema_or_changeset()) :: {:ok, schema()}
+  @callback delete(schema_or_changeset()) :: {:ok, schema()}
+  @callback delete_all(queryable()) :: {:ok, pos_integer()}
+  @callback delete_all(queryable(), opts()) :: {:ok, pos_integer()}
+end

--- a/lib/guardian/db/adapter.ex
+++ b/lib/guardian/db/adapter.ex
@@ -13,9 +13,33 @@ defmodule Guardian.DB.Adapter do
   @typep opts :: keyword()
   @typep id :: pos_integer() | binary() | Ecto.UUID.t()
 
+  @doc """
+  Retrieves JWT token
+  Used in `Guardian.DB.Token.find_by_claims/1`
+  """
   @callback one(queryable()) :: nil | schema()
+
+  @doc """
+  Persists JWT token
+  Used in `Guardian.DB.Token.create/2`
+  """
   @callback insert(schema_or_changeset()) :: {:ok, schema()}
+
+  @doc """
+  Deletes JWT token
+  Used in `Guardian.DB.Token.destroy_token/3`
+  """
   @callback delete(schema_or_changeset()) :: {:ok, schema()}
+
+  @doc """
+  Deletes all JWT tokens of a user
+  Used in `Guardian.DB.Token.destroy_by_sub/1`
+  """
   @callback delete_all(queryable()) :: {:ok, pos_integer()}
+
+  @doc """
+  Purges all JWT tokens
+  Used in `Guardian.DB.Token.purge_expired_tokens/0
+  """
   @callback delete_all(queryable(), opts()) :: {:ok, pos_integer()}
 end


### PR DESCRIPTION
Just adding an [storage adapter](https://github.com/ueberauth/guardian_db/issues/119#issuecomment-809875685) (by @aleDsz) so my [Guardian.DB Redis plugin](https://github.com/alexfilatov/guardian_redis) could work with the `guardian_db` package as a dependency (currently it's using dependency from my fork).

I believe I will need to mention this in the README, will add this shortly