### PR TITLE
Changes to DB adapter

### DIFF
--- a/lib/guardian/db/adapter.ex
+++ b/lib/guardian/db/adapter.ex
@@ -8,7 +8,8 @@ defmodule Guardian.DB.Adapter do
 
   @typep query :: Ecto.Query.t()
   @typep schema :: Ecto.Schema.t()
-  @typep schema_or_changeset :: schema() | Ecto.Changeset.t()
+  @typep changeset :: Ecto.Changeset.t()
+  @typep schema_or_changeset :: schema() | changeset()
   @typep queryable :: query() | schema()
   @typep opts :: keyword()
   @typep id :: pos_integer() | binary() | Ecto.UUID.t()
@@ -17,29 +18,24 @@ defmodule Guardian.DB.Adapter do
   Retrieves JWT token
   Used in `Guardian.DB.Token.find_by_claims/1`
   """
-  @callback one(queryable()) :: nil | schema()
+  @callback one(queryable()) :: schema() | nil
 
   @doc """
   Persists JWT token
   Used in `Guardian.DB.Token.create/2`
   """
-  @callback insert(schema_or_changeset()) :: {:ok, schema()}
+  @callback insert(schema_or_changeset()) :: {:ok, schema()} | {:error, changeset()}
 
   @doc """
   Deletes JWT token
   Used in `Guardian.DB.Token.destroy_token/3`
   """
-  @callback delete(schema_or_changeset()) :: {:ok, schema()}
-
-  @doc """
-  Deletes all JWT tokens of a user
-  Used in `Guardian.DB.Token.destroy_by_sub/1`
-  """
-  @callback delete_all(queryable()) :: {:ok, pos_integer()}
+  @callback delete(schema_or_changeset(), opts()) :: {:ok, schema()} | {:error, changeset()}
 
   @doc """
   Purges all JWT tokens
-  Used in `Guardian.DB.Token.purge_expired_tokens/0
+  Used in `Guardian.DB.Token.purge_expired_tokens/0 and in `Guardian.DB.Token.destroy_by_sub/1`
+  Returns a tuple containing the number of entries and any returned result as second element.
   """
-  @callback delete_all(queryable(), opts()) :: {:ok, pos_integer()}
+  @callback delete_all(queryable(), opts()) :: {integer(), nil | [term()]}
 end


### PR DESCRIPTION
- fixed return values of callbacks
- removed redundant delete_all/1 callback

solves https://github.com/ueberauth/guardian_db/issues/119