### PR TITLE
Update Adapter and implement EctoAdapter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,7 @@ use Mix.Config
 config :guardian, Guardian.DB,
   issuer: "GuardianDB",
   secret_key: "HcdlxxmyDRvfrwdpjUPh2M8mWP+KtpOQK1g6fT5SHrnflSY8KiWeORqN6IZSJYTA",
+  adapter: Guardian.DB.EctoAdapter,
   repo: Guardian.DB.TestSupport.Repo
 
 config :guardian_db, ecto_repos: [Guardian.DB.TestSupport.Repo]

--- a/lib/guardian/db.ex
+++ b/lib/guardian/db.ex
@@ -225,13 +225,6 @@ defmodule Guardian.DB do
     {:ok, amount_deleted}
   end
 
-  @doc false
-  def repo do
-    :guardian
-    |> Application.fetch_env!(Guardian.DB)
-    |> Keyword.fetch!(:repo)
-  end
-
   defp token_types do
     :guardian
     |> Application.fetch_env!(Guardian.DB)

--- a/lib/guardian/db/adapter.ex
+++ b/lib/guardian/db/adapter.ex
@@ -12,9 +12,14 @@ defmodule Guardian.DB.Adapter do
   @typep schema_or_changeset :: schema() | changeset()
   @typep claims :: map()
   @typep exp :: pos_integer()
-  @typep sub :: string()
+  @typep sub :: binary()
   @typep opts :: keyword()
   @typep id :: pos_integer() | binary() | Ecto.UUID.t()
+
+  @doc """
+  Optional callback for creating a changeset
+  """
+  @callback changeset(map(), opts()) :: changeset()
 
   @doc """
   Retrieves JWT token

--- a/lib/guardian/db/adapter.ex
+++ b/lib/guardian/db/adapter.ex
@@ -10,7 +10,9 @@ defmodule Guardian.DB.Adapter do
   @typep schema :: Ecto.Schema.t()
   @typep changeset :: Ecto.Changeset.t()
   @typep schema_or_changeset :: schema() | changeset()
-  @typep queryable :: query() | schema()
+  @typep claims :: map()
+  @typep exp :: pos_integer()
+  @typep sub :: string()
   @typep opts :: keyword()
   @typep id :: pos_integer() | binary() | Ecto.UUID.t()
 
@@ -18,13 +20,13 @@ defmodule Guardian.DB.Adapter do
   Retrieves JWT token
   Used in `Guardian.DB.Token.find_by_claims/1`
   """
-  @callback one(queryable()) :: schema() | nil
+  @callback one(claims(), opts()) :: schema() | nil
 
   @doc """
   Persists JWT token
   Used in `Guardian.DB.Token.create/2`
   """
-  @callback insert(schema_or_changeset()) :: {:ok, schema()} | {:error, changeset()}
+  @callback insert(schema_or_changeset(), opts()) :: {:ok, schema()} | {:error, changeset()}
 
   @doc """
   Deletes JWT token
@@ -33,9 +35,16 @@ defmodule Guardian.DB.Adapter do
   @callback delete(schema_or_changeset(), opts()) :: {:ok, schema()} | {:error, changeset()}
 
   @doc """
-  Purges all JWT tokens
-  Used in `Guardian.DB.Token.purge_expired_tokens/0 and in `Guardian.DB.Token.destroy_by_sub/1`
+  Purges all JWT tokens for a given subject.
+
   Returns a tuple containing the number of entries and any returned result as second element.
   """
-  @callback delete_all(queryable(), opts()) :: {integer(), nil | [term()]}
+  @callback delete_by_sub(sub(), opts()) :: {integer(), nil | [term()]}
+
+  @doc """
+  Purges all expired JWT tokens.
+
+  Returns a tuple containing the number of entries and any returned result as second element.
+  """
+  @callback purge_expired_tokens(exp(), opts()) :: {integer(), nil | [term()]}
 end

--- a/lib/guardian/db/adapter/ecto.ex
+++ b/lib/guardian/db/adapter/ecto.ex
@@ -1,0 +1,71 @@
+defmodule Guardian.DB.EctoAdapter do
+  @moduledoc """
+  Implement the Guardian.DB.Adapter for Ecto.Repo
+  """
+
+  import Ecto.Query
+
+  alias Guardian.DB.Token
+
+  @behaviour Guardian.DB.Adapter
+
+  @impl true
+  def one(claims, opts) do
+    prefix = Keyword.get(opts, :prefix, nil)
+    jti = Map.get(claims, "jti")
+    aud = Map.get(claims, "aud")
+
+    query_schema()
+    |> where([token], token.jti == ^jti and token.aud == ^aud)
+    |> ecto_repo().one(prefix: prefix)
+  end
+
+  @impl true
+  def insert(changeset, opts) do
+    prefix = Keyword.get(opts, :prefix, nil)
+    ecto_repo().insert(changeset, prefix: prefix)
+  end
+
+  @impl true
+  def delete(record, opts) do
+    prefix = Keyword.get(opts, :prefix, nil)
+    ecto_repo().delete(record, prefix: prefix)
+  end
+
+  @impl true
+  def delete_by_sub(sub, opts) do
+    prefix = Keyword.get(opts, :prefix, nil)
+
+    query_schema()
+    |> where([token], token.sub == ^sub)
+    |> ecto_repo().delete_all(prefix: prefix)
+  end
+
+  @impl true
+  def purge_expired_tokens(timestamp, opts) do
+    prefix = Keyword.get(opts, :prefix, nil)
+    timestamp = Guardian.timestamp()
+
+    query_schema()
+    |> where([token], token.exp < ^timestamp)
+    |> ecto_repo().delete_all(prefix: prefix)
+  end
+
+  @doc false
+  def query_schema do
+    {schema_name(), Token}
+  end
+
+  @doc false
+  def schema_name do
+    :guardian
+    |> Application.fetch_env!(Guardian.DB)
+    |> Keyword.get(:schema_name, "guardian_tokens")
+  end
+
+  def ecto_repo do
+    :guardian
+    |> Application.fetch_env!(Guardian.DB)
+    |> Keyword.fetch!(:repo)
+  end
+end

--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -97,6 +97,6 @@ defmodule Guardian.DB.Token do
   defp adapter do
     :guardian
     |> Application.fetch_env!(Guardian.DB)
-    |> Keyword.fetch!(:adapter)
+    |> Keyword.get(:adapter, Guardian.DB.EctoAdapter)
   end
 end

--- a/lib/guardian/db/token.ex
+++ b/lib/guardian/db/token.ex
@@ -29,7 +29,7 @@ defmodule Guardian.DB.Token do
   Find one token by matching jti and aud.
   """
   def find_by_claims(claims) do
-    adapter().one(claims, prefix: prefix())
+    adapter().one(claims, config())
   end
 
   @doc """
@@ -42,11 +42,9 @@ defmodule Guardian.DB.Token do
       |> Map.put("claims", claims)
 
     %Token{}
-    |> Ecto.put_meta(source: schema_name())
-    |> Ecto.put_meta(prefix: prefix())
     |> cast(prepared_claims, @allowed_fields)
     |> validate_required(@required_fields)
-    |> adapter().insert(prefix: prefix())
+    |> adapter().insert(config())
   end
 
   @doc """
@@ -56,38 +54,24 @@ defmodule Guardian.DB.Token do
   def purge_expired_tokens do
     timestamp = Guardian.timestamp()
 
-    adapter().purge_expired_tokens(timestamp, prefix: prefix())
+    adapter().purge_expired_tokens(timestamp, config())
   end
 
   @doc false
   def destroy_by_sub(sub) do
-    adapter().delete_by_sub(sub, prefix: prefix())
+    adapter().delete_by_sub(sub, config())
   end
 
   @doc false
-  def query_schema do
-    {schema_name(), Token}
-  end
-
-  @doc false
-  def schema_name do
-    :guardian
-    |> Application.fetch_env!(Guardian.DB)
-    |> Keyword.get(:schema_name, "guardian_tokens")
-  end
-
-  @doc false
-  def prefix do
-    :guardian
-    |> Application.fetch_env!(Guardian.DB)
-    |> Keyword.get(:prefix, nil)
+  defp config do
+    Application.fetch_env!(:guardian, Guardian.DB)
   end
 
   @doc false
   def destroy_token(nil, claims, jwt), do: {:ok, {claims, jwt}}
 
   def destroy_token(model, claims, jwt) do
-    case adapter().delete(model, prefix: prefix()) do
+    case adapter().delete(model, config()) do
       {:error, _} -> {:error, :could_not_revoke_token}
       nil -> {:error, :could_not_revoke_token}
       _ -> {:ok, {claims, jwt}}
@@ -95,8 +79,6 @@ defmodule Guardian.DB.Token do
   end
 
   defp adapter do
-    :guardian
-    |> Application.fetch_env!(Guardian.DB)
-    |> Keyword.get(:adapter, Guardian.DB.EctoAdapter)
+    Keyword.get(config(), :adapter, Guardian.DB.EctoAdapter)
   end
 end

--- a/lib/mix/tasks/guardian_db.gen.migration.ex
+++ b/lib/mix/tasks/guardian_db.gen.migration.ex
@@ -28,17 +28,20 @@ defmodule Mix.Tasks.Guardian.Db.Gen.Migration do
         |> Application.app_dir()
         |> Path.join("priv/templates/migration.exs.eex")
 
+      config = Application.fetch_env!(:guardian, Guardian.DB)
+
       schema_name =
-        :guardian
-        |> Application.fetch_env!(Guardian.DB)
+        config
         |> Keyword.get(:schema_name, "guardian_tokens")
         |> String.to_atom()
+
+      prefix = Keyword.get(config, :prefix, nil)
 
       generated_file =
         EEx.eval_file(source_path,
           module_prefix: app_module(),
           schema_name: schema_name,
-          db_prefix: Token.prefix()
+          db_prefix: prefix
         )
 
       target_file = Path.join(path, "#{timestamp()}_guardiandb.exs")

--- a/test/guardian/db_fail_test.exs
+++ b/test/guardian/db_fail_test.exs
@@ -1,8 +1,7 @@
 defmodule Guardian.DBFailTest do
-  alias Guardian.DB.Token
   use Guardian.DB.TestSupport.CaseTemplate
 
-  test "after_encode_and_sign_in is fails", context do
+  test "after_encode_and_sign_in is fails" do
     token = get_token()
     assert token == nil
 

--- a/test/guardian/db_test.exs
+++ b/test/guardian/db_test.exs
@@ -125,6 +125,6 @@ defmodule Guardian.DBTest do
     )
 
     assert Guardian.DB.revoke_all(sub) == {:ok, 3}
-    assert Repo.all(Token.query_schema()) == []
+    assert Repo.all({"guardian_tokens", Token}) == []
   end
 end

--- a/test/support/case_template.ex
+++ b/test/support/case_template.ex
@@ -24,5 +24,12 @@ defmodule Guardian.DB.TestSupport.CaseTemplate do
     :ok
   end
 
-  def get_token(token_id \\ "token-uuid"), do: Repo.get(Token.query_schema(), token_id)
+  def get_token(token_id \\ "token-uuid") do
+    schema_name =
+      :guardian
+      |> Application.fetch_env!(Guardian.DB)
+      |> Keyword.get(:schema_name, "guardian_tokens")
+
+    Repo.get({schema_name, Token}, token_id)
+  end
 end


### PR DESCRIPTION
Howdy @yordis / @alexfilatov :wave: After reviewing #128 and looking to implement an adapter for ETS I ran into some snags that I should have caught in the first PR so I wanted to open this for the sake of conversation so we could identify if these are issues and if so, the best way to resolve them.

The first issue that I noticed when I went to implement the `ETS` adapter was that behaviour we setup relies pretty heavily on Ecto. If you're not working in Ecto having to deconstruct Ecto queries to get sensible data from them is not desirable. I propose we revisit the adapter behaviour and consider how we could reduce the dependency on Ecto, for this PR I updated the behavior in 4 ways:

1. I updated all the callbacks to take the `opts` as pretty much any adapter will need configuration passed into it per function
2. I updated `one/2` to take in the claims rather than a query.
3. I replaced `delete_all/2` with `delete_by_sub/2` to delete by subject. The original function took a query for either sub or purge, I thought it might be best to break this up.
4. I added `purge_expired_tokens` to handle the second part of the aforementioned point.

Other changes I made in this PR to discuss:

I implemented the Ecto adapter and updated Token to rely on the adapter to do more work.

As-is this still does rely on Ecto Changesets being passed into the adapter. That's not as bad as queries but I'm not sure that is desirable either. Thought?