### PR TITLE
Fix: documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Breaking changes
 
 * `Guardian.DB.Token.SweeperServer` becomes `Guardian.DB.Sweeper`
+* `sweep_interval` option is no longer supported. Specify interval directly instead.
+* Sweep intervals are now specified in milliseconds instead of minutes.
 
 ## v2.0.2
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To sweep expired tokens from your db you should add
 
 ```elixir
 children = [
-  {Guardian.DB.Sweeper, [interval: 60]}
+  {Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]} # 1 hour
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ config :guardian, Guardian.DB,
   repo: MyApp.Repo, # Add your repository module
   schema_name: "guardian_tokens", # default
   token_types: ["refresh_token"], # store all token types if not set
-  sweep_interval: 60 # default: 60 minutes
 ```
 
 To sweep expired tokens from your db you should add
-`Guardian.DB.Token.SweeperServer` to your supervision tree.
+`Guardian.DB.Sweeper` to your supervision tree.
 
 ```elixir
 children = [
-  {Guardian.DB.Token.SweeperServer, []}
+  {Guardian.DB.Sweeper, [interval: 60]}
 ]
 ```
 
@@ -173,8 +172,8 @@ approach to authentication!
 
 ### Create your own Repo
 
-We created `Guardian.DB.Adapter` behaviour to allow creating other repositories for persisting JWT tokens. 
-You need to implement the `Guardian.DB.Adapter` behavior working with your preferred storage.     
+We created `Guardian.DB.Adapter` behaviour to allow creating other repositories for persisting JWT tokens.
+You need to implement the `Guardian.DB.Adapter` behavior working with your preferred storage.
 
 ### Adapters
 

--- a/lib/guardian/db.ex
+++ b/lib/guardian/db.ex
@@ -32,8 +32,6 @@ defmodule Guardian.DB do
 
   * `prefix` - The schema prefix to use.
   * `schema_name` - The name of the schema to use. Default "guardian_tokens".
-  * `sweep_interval` - The interval between db sweeps to remove old tokens.
-  Default 60 (minutes).
 
   ### Sweeper
 

--- a/lib/guardian/db.ex
+++ b/lib/guardian/db.ex
@@ -39,8 +39,11 @@ defmodule Guardian.DB do
   `Guardian.DB.Sweeper` to your supervision tree.
   In your supervisor add it as a worker
 
+  * `interval` - The interval between db sweeps to remove old tokens, in
+  milliseconds. Defaults to 1 hour.
+
   ```elixir
-  worker(Guardian.DB.Sweeper, [interval: 60])
+  worker(Guardian.DB.Sweeper, [interval: 60 * 60 * 1000])
   ```
 
   # Migration

--- a/lib/guardian/db/sweeper.ex
+++ b/lib/guardian/db/sweeper.ex
@@ -18,10 +18,10 @@ defmodule Guardian.DB.Sweeper do
 
   alias Guardian.DB.Token
 
-  @sixty_minutes 60
+  @sixty_minutes 60 * 60 * 1000
 
   def start_link(opts) do
-    interval = Keyword.get(opts, :interval, @sixty_minutes) |> minute_to_ms()
+    interval = Keyword.get(opts, :interval, @sixty_minutes)
     GenServer.start_link(__MODULE__, [interval: interval], name: __MODULE__)
   end
 
@@ -72,13 +72,4 @@ defmodule Guardian.DB.Sweeper do
 
     [interval: interval, timer: timer]
   end
-
-  defp minute_to_ms(value) when is_binary(value) do
-    value
-    |> String.to_integer()
-    |> minute_to_ms()
-  end
-
-  defp minute_to_ms(value) when value < 1, do: 1000
-  defp minute_to_ms(value), do: round(value * 60 * 1000)
 end

--- a/lib/guardian/db/sweeper.ex
+++ b/lib/guardian/db/sweeper.ex
@@ -5,9 +5,14 @@ defmodule Guardian.DB.Sweeper do
   To leverage the automated Sweeper functionality update your project's Application
   file to include the following child in your supervision tree:
 
+  * `interval` - The interval between db sweeps to remove old tokens, in
+  milliseconds. Defaults to 1 hour.
+
   ## Example
 
-    worker(Guardian.DB.Sweeper, [interval: 60])
+  ```elixir
+    worker(Guardian.DB.Sweeper, [interval: 60 * 60 * 1000])
+  ```
   """
   use GenServer
 

--- a/lib/guardian/db/sweeper.ex
+++ b/lib/guardian/db/sweeper.ex
@@ -13,10 +13,10 @@ defmodule Guardian.DB.Sweeper do
 
   alias Guardian.DB.Token
 
-  @sixty_minutes 60 * 60 * 1000
+  @sixty_minutes 60
 
   def start_link(opts) do
-    interval = Keyword.get(opts, :interval, @sixty_minutes)
+    interval = Keyword.get(opts, :interval, @sixty_minutes) |> minute_to_ms()
     GenServer.start_link(__MODULE__, [interval: interval], name: __MODULE__)
   end
 
@@ -67,4 +67,13 @@ defmodule Guardian.DB.Sweeper do
 
     [interval: interval, timer: timer]
   end
+
+  defp minute_to_ms(value) when is_binary(value) do
+    value
+    |> String.to_integer()
+    |> minute_to_ms()
+  end
+
+  defp minute_to_ms(value) when value < 1, do: 1000
+  defp minute_to_ms(value), do: round(value * 60 * 1000)
 end


### PR DESCRIPTION
~~Based on the changes to the example in #138, it seems that the intended use case is still to specify the interval in minutes:~~

* ~~https://github.com/ueberauth/guardian_db/blob/5bcc4d595ae0e3029bd449df59aafe223ff44c75/lib/guardian/db.ex#L35-L36~~
* ~~https://github.com/ueberauth/guardian_db/blob/5bcc4d595ae0e3029bd449df59aafe223ff44c75/lib/guardian/db.ex#L44-L46~~

~~But in the refactoring done in #130, the interval option is passed directly into the worker, without going through the minute-to-millisecond conversion.~~

~~This PR restores the original behavior, and also updates the outdated example in the README  following the refactor.~~

If we don't want to keep this minute-to-ms behavior, the alternative is to update the examples accordingly; in that case, this PR could be the starting point for the discussion.