### PR TITLE
Update README.md for v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install `Guardian.DB`, first add it to your `mix.exs` file:
 ```elixir
 defp deps do
   [
-    {:guardian_db, "~> 2.0"}
+    {:guardian_db, "~> 3.0"}
   ]
 end
 ```
@@ -37,10 +37,14 @@ run `mix guardian.db.gen.migration` to generate a migration.
 
 ```elixir
 config :guardian, Guardian.DB,
+  adapter: Guardian.DB.EctoAdapter, # default
   repo: MyApp.Repo, # Add your repository module
   schema_name: "guardian_tokens", # default
   token_types: ["refresh_token"], # store all token types if not set
 ```
+
+To use [ETS](https://hexdocs.pm/elixir/1.16/erlang-term-storage.html) instead
+of Ecto for storing tokens, you can set `adapter` to `Guardian.DB.ETSAdapter`.
 
 To sweep expired tokens from your db you should add
 `Guardian.DB.Sweeper` to your supervision tree.


### PR DESCRIPTION
This pull request updates the documentation to reflect the breaking changes in v3.

It would be good to release `master` as a tag (say 3.0.1), or cherry-pick this commit along with 1003ca148525d8589a7b154fcb9f2a257d27eec2 and 1d1671934ae4c38c02310c324044d3542ec599ad and release that instead, as soon as possible. Namely, the current documentation on hexdocs is incorrect. Following it gives the somewhat vague error:

```
* (Mix) Could not start application myapp: MyApp.Application.start(:normal, []) returned an error: shutdown: failed to start child: MyApp.Telemetry
    ** (EXIT) an exception was raised:
        ** (ArgumentError) The module Guardian.DB.Token.SweeperServer was given as a child to a supervisor but it does not exist
```